### PR TITLE
Try pulling exercise sets for all activity types

### DIFF
--- a/src/manifest_v2.json
+++ b/src/manifest_v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Garmin Workout Downloader",
   "description": "Download workout data from the Garmin Connect console. Strength workouts are downloaded with exercise names, reps and weights.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "homepage_url": "https://github.com/labsansis/garmin-workout-downloader",
   "icons": {
     "48": "icons/icon-dumbbell.svg"

--- a/src/manifest_v3.json
+++ b/src/manifest_v3.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Garmin Workout Downloader",
   "description": "Download workout data from the Garmin Connect console. Strength workouts are downloaded with exercise names, reps and weights.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "homepage_url": "https://github.com/labsansis/garmin-workout-downloader",
   "icons": {
     "16": "icons/icon-dumbbell-16x16.png",

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -47,15 +47,13 @@ browser.runtime.onMessage.addListener((message) => {
     document.getElementById("loader-container").style.display = "none";
     document.getElementById("error-content").style.display = "none";
     document.getElementById("success-content").style.display = "block";
-    document.getElementById(
-      "success-content",
-    ).innerHTML = `Downloaded ${message.numActivitiesFetched} activities!`;
+    document.getElementById("success-content").innerHTML =
+      `Downloaded ${message.numActivitiesFetched} activities!`;
   } else if (message.status === "loadingError") {
     document.getElementById("loader-container").style.display = "none";
     document.getElementById("success-content").style.display = "none";
     document.getElementById("error-content").style.display = "block";
-    document.getElementById(
-      "error-content",
-    ).innerHTML = `Failed to retrieve workout data`;
+    document.getElementById("error-content").innerHTML =
+      `Failed to retrieve workout data`;
   }
 });

--- a/src/workout_cs.js
+++ b/src/workout_cs.js
@@ -43,7 +43,7 @@
 
   async function fetchActivityExerciseSets(activityId, authHeader) {
     const url = `https://connect.garmin.com/activity-service/activity/${activityId}/exerciseSets`;
-    const response = await fetch(url, {
+    const responseJson = await fetch(url, {
       credentials: "include",
       headers: {
         Accept: "application/json, text/javascript, */*; q=0.01",
@@ -62,21 +62,21 @@
       referrer: "https://connect.garmin.com/modern/activities",
       method: "GET",
       mode: "cors",
-    });
-    let rj = await response.json();
-    return rj.exerciseSets || [];
+    })
+      .then((resp) => {
+        if (resp.ok) return resp.json();
+        return {};
+      })
+      .catch((err) => {
+        return {};
+      });
+    return responseJson.exerciseSets || [];
   }
 
   async function enrichAcitvity(activity, authHeader) {
-    if (
-      activity &&
-      activity.activityType &&
-      activity.activityType.typeKey === "strength_training"
-    ) {
-      activity.fullExerciseSets = [
-        ...(await fetchActivityExerciseSets(activity.activityId, authHeader)),
-      ];
-    }
+    activity.fullExerciseSets = [
+      ...(await fetchActivityExerciseSets(activity.activityId, authHeader)),
+    ];
     return activity;
   }
 


### PR DESCRIPTION
Currently the extension only makes a request to the `exerciseSets` internal Garmin API endpoint for activities explicitly marked as strength training. As reported in #14 by @Memo4ninja, other workout types can also have structured exercise information.

I looked into this and while this is by no means exhaustive or conclusive it looks like the Garmin Connect API calls the same `exerciseSets` endpoint for other workouts as well where there is something to fetch. This PR removes the workout type filter and calls the endpoint for all activities.

One implication here is that the call might fail with a non-2xx response or something like that for activities that have no structured exercise info, so adding some logic here to handle that too.