### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/src/manifest_v2.json
+++ b/src/manifest_v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Garmin Workout Downloader",
   "description": "Download workout data from the Garmin Connect console. Strength workouts are downloaded with exercise names, reps and weights.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage_url": "https://github.com/labsansis/garmin-workout-downloader",
   "icons": {
     "48": "icons/icon-dumbbell.svg"

--- a/src/manifest_v3.json
+++ b/src/manifest_v3.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Garmin Workout Downloader",
   "description": "Download workout data from the Garmin Connect console. Strength workouts are downloaded with exercise names, reps and weights.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage_url": "https://github.com/labsansis/garmin-workout-downloader",
   "icons": {
     "16": "icons/icon-dumbbell-16x16.png",


### PR DESCRIPTION
The 1.1.0 version was uploaded to Firefox and Chrome stores from a non-main branch (on which I was doing some work for connecting the extension directly to the workout stats UI). This PR just bumps the version so that I can upload it to the relevant browser stores as it was intended in 1.1.0.